### PR TITLE
Activate mode for the .dzn and .fzn extensions

### DIFF
--- a/minizinc-ts-mode.el
+++ b/minizinc-ts-mode.el
@@ -185,7 +185,7 @@ solver to use. Otherwise, the solver depends on the value of
     (minizinc-ts--ts-setup)))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist (cons "\\.mzn\\'" #'minizinc-ts-mode))
+(add-to-list 'auto-mode-alist (cons "\\.[mdf]zn\\'" #'minizinc-ts-mode))
 
 (add-to-list 'treesit-language-source-alist
              '(minizinc . ("https://github.com/shackle-rs/shackle" nil "parsers/tree-sitter-minizinc/src")))


### PR DESCRIPTION
The Minizinc documentation promotes the .dzn extension for data files and the .fzn extension for intermediate FlatZinc output.  Since they use the same syntax, they should also be using this mode.  The binary MiniZinc package for Windows also links both file extensions to the bundled IDE.